### PR TITLE
feat: 필터 드롭다운 스크롤 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
 <span class="material-symbols-outlined text-sm">filter_list</span>
 <span>필터링</span>
 </button>
-<div class="hidden absolute left-0 md:left-auto md:right-0 mt-2 w-full sm:w-80 bg-white dark:bg-slate-800 border border-slate-200 dark:border-border-dark rounded-xl shadow-lg z-50 p-4" id="filter-dropdown">
+<div class="hidden absolute left-0 md:left-auto md:right-0 mt-2 w-full sm:w-80 bg-white dark:bg-slate-800 border border-slate-200 dark:border-border-dark rounded-xl shadow-lg z-50 p-4 max-h-96 overflow-y-auto notion-scroll" id="filter-dropdown">
 <div class="flex justify-between items-center mb-4">
 <h3 class="font-bold">필터</h3>
 <button class="text-sm text-primary hover:underline" id="reset-filters">초기화</button>


### PR DESCRIPTION
## Summary
- 필터 드롭다운에 max-height(384px)와 overflow-y-auto 추가
- notion-scroll 클래스를 적용하여 스타일 일관성 유지
- 필터 옵션이 많아도 화면을 벗어나지 않고 스크롤 가능

## Test plan
- [ ] 필터 버튼 클릭 시 드롭다운이 정상적으로 표시되는지 확인
- [ ] 필터 옵션이 많을 때 스크롤이 정상적으로 동작하는지 확인
- [ ] 다크 모드에서도 스크롤바가 잘 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)