### PR TITLE
fix: 다가오는 동아리 일정에서 마감일 지난 동아리 제외

### DIFF
--- a/script.js
+++ b/script.js
@@ -238,9 +238,12 @@ function renderDeadlines() {
     const upcoming = getAllClubs().filter(club => {
         const recruitEnd = parseDate(club.recruitEnd);
         if (!recruitEnd) return false;
-        
+
+        // 같은 년도에서 이미 마감일이 지난 동아리는 제외
+        if (recruitEnd.getFullYear() === today.getFullYear() && recruitEnd < today) return false;
+
         const endMonth = recruitEnd.getMonth();
-        
+
         return endMonth === currentMonth || endMonth === nextMonth;
     }).map(club => {
         const endDate = parseDate(club.recruitEnd);


### PR DESCRIPTION
## Summary
- 다가오는 동아리 일정에서 같은 년도 중 이미 모집 마감일이 지난 동아리를 제외하도록 수정
- `renderDeadlines()`의 필터링 조건에 `recruitEnd < today` 체크 추가

Closes #36

## Test plan
- [ ] 오늘 날짜 기준으로 이미 마감된 동아리가 "다가오는 동아리 일정"에 표시되지 않는지 확인
- [ ] 아직 마감되지 않은 동아리는 정상적으로 표시되는지 확인
- [ ] 다른 년도(작년)의 동아리는 기존대로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)