### PR TITLE
feat: footer에 개인정보 처리방침 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,8 +201,9 @@
 </div>
 </div>
 </div>
-<div class="mt-6 md:mt-8 flex justify-center items-center text-slate-500 dark:text-slate-500 text-xs sm:text-sm max-w-7xl mx-auto">
+<div class="mt-6 md:mt-8 flex flex-col justify-center items-center text-slate-500 dark:text-slate-500 text-xs sm:text-sm max-w-7xl mx-auto gap-1">
 <p>© IT Club DB. All information updated daily.</p>
+<a href="https://dazzling-myth-cd2.notion.site/3097c67ff1e68022a012f2c5e0389e9b" target="_blank" class="hover:text-slate-700 dark:hover:text-slate-300 underline transition-colors">개인정보 처리방침</a>
 </div>
 </main>
 </div>

--- a/marketing.html
+++ b/marketing.html
@@ -201,8 +201,9 @@
 </div>
 </div>
 </div>
-<div class="mt-6 md:mt-8 flex justify-center items-center text-slate-500 dark:text-slate-500 text-xs sm:text-sm max-w-7xl mx-auto">
+<div class="mt-6 md:mt-8 flex flex-col justify-center items-center text-slate-500 dark:text-slate-500 text-xs sm:text-sm max-w-7xl mx-auto gap-1">
 <p>© 마케팅/경영 Club DB. All information updated daily.</p>
+<a href="https://dazzling-myth-cd2.notion.site/3097c67ff1e68022a012f2c5e0389e9b" target="_blank" class="hover:text-slate-700 dark:hover:text-slate-300 underline transition-colors">개인정보 처리방침</a>
 </div>
 </main>
 </div>


### PR DESCRIPTION
## Summary
- `index.html`, `marketing.html` 두 페이지의 footer에 개인정보 처리방침 노션 링크 추가
- footer 레이아웃을 `flex-col`로 변경하여 저작권 텍스트 아래에 링크 배치

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)