### PR TITLE
hotfix: 모바일 화면에서 카테고리 버튼 드롭다운 대응

### DIFF
--- a/bootcamp.html
+++ b/bootcamp.html
@@ -66,7 +66,7 @@
 
             <div class="flex items-center gap-2 mt-6">
                 <!-- 모바일 드롭다운 -->
-                <select onchange="window.location.href=this.value" class="category-select md:hidden px-4 py-2 rounded-full bg-emerald-500 text-white font-bold text-sm transition-all appearance-none cursor-pointer pr-8">
+                <select onchange="window.location.href=this.value" class="category-select md:hidden px-4 py-2 rounded-full bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800 font-bold text-sm transition-all appearance-none cursor-pointer pr-8">
                     <option value="/">IT</option>
                     <option value="/marketing">마케팅/경영</option>
                     <option value="/bootcamp" selected>부트캠프</option>

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
 
             <div class="flex items-center gap-2 mt-6">
                 <!-- 모바일 드롭다운 -->
-                <select onchange="window.location.href=this.value" class="category-select md:hidden px-4 py-2 rounded-full bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 font-bold text-sm transition-all appearance-none cursor-pointer pr-8">
+                <select onchange="window.location.href=this.value" class="category-select md:hidden px-4 py-2 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 font-bold text-sm transition-all appearance-none cursor-pointer pr-8">
                     <option value="/" selected>IT</option>
                     <option value="/marketing">마케팅/경영</option>
                     <option value="/bootcamp">부트캠프</option>

--- a/marketing.html
+++ b/marketing.html
@@ -66,7 +66,7 @@
 
             <div class="flex items-center gap-2 mt-6">
                 <!-- 모바일 드롭다운 -->
-                <select onchange="window.location.href=this.value" class="category-select md:hidden px-4 py-2 rounded-full bg-pink-500 text-white font-bold text-sm transition-all appearance-none cursor-pointer pr-8">
+                <select onchange="window.location.href=this.value" class="category-select md:hidden px-4 py-2 rounded-full bg-pink-50 dark:bg-pink-900/30 text-pink-600 dark:text-pink-400 border border-pink-200 dark:border-pink-800 font-bold text-sm transition-all appearance-none cursor-pointer pr-8">
                     <option value="/">IT</option>
                     <option value="/marketing" selected>마케팅/경영</option>
                     <option value="/bootcamp">부트캠프</option>

--- a/style.css
+++ b/style.css
@@ -62,7 +62,10 @@ body {
 
 /* 모바일 카테고리 드롭다운 화살표 */
 .category-select {
-    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='white' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2364748b' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 0.75rem center;
+}
+.dark .category-select {
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2394a3b8' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
 }


### PR DESCRIPTION
## Summary
- 모바일 화면(md 미만)에서 IT/마케팅·경영/부트캠프 카테고리 버튼을 `<select>` 드롭다운으로 변경
- 데스크톱(md 이상)에서는 기존 pill 버튼 UI 유지
- 제휴 문의, 피드백 보내기 버튼은 그대로 유지하며 `flex-wrap`으로 줄바꿈 대응

## Changes
- `index.html`, `marketing.html`, `bootcamp.html`: 카테고리 버튼 영역에 모바일 드롭다운 추가 및 데스크톱 버튼 `hidden md:inline-block` 적용
- `style.css`: `.category-select` 클래스 추가 (드롭다운 화살표 커스텀 스타일)

## Test plan
- [ ] 모바일 화면(< 768px)에서 드롭다운이 올바르게 표시되는지 확인
- [ ] 드롭다운 선택 시 해당 페이지로 정상 이동하는지 확인
- [ ] 데스크톱 화면(≥ 768px)에서 기존 pill 버튼이 그대로 표시되는지 확인
- [ ] 제휴 문의, 피드백 보내기 버튼이 모든 화면에서 정상 표시되는지 확인
- [ ] 다크모드에서 드롭다운 스타일 확인

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)