### PR TITLE
[feat] 구름톤 유니브 일정 변경

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,7 +72,7 @@ const PAGE_CATEGORIES = {
 
 const Club = {
     // 2025-01-20
-    GOORMTHON_UNIV: { name: "구름톤 유니브", link: "https://9oormthon.university/", dots: "🌕", icon: "☁️", themeColor: "slate-500", recruitStart: "1월 20일 2025", recruitEnd: "2월 12일 2025", activity: ["3월", "4월", "5월", "6월", "7월"], eligibility: [Eligibility.UNIVERSITY], description: "'함께 성장'이라는 핵심가치를 실현하며 전국의 대학생들과 자유롭게 교류하고 학습하며 성장하는 카카오와 구름이 함께하는 대학생 대상 해커톤", fields: [Field.PM, Field.DESIGN, Field.WEB, Field.SPRING, Field.REACT_NATIVE] },
+    GOORMTHON_UNIV: { name: "구름톤 유니브", link: "https://9oormthon.university/", dots: "🌕", icon: "☁️", themeColor: "slate-500", recruitStart: "2월 26일 2026", recruitEnd: "3월 23일 2026", activity: ["3월", "4월", "5월", "6월", "7월"], eligibility: [Eligibility.UNIVERSITY], description: "'함께 성장'이라는 핵심가치를 실현하며 전국의 대학생들과 자유롭게 교류하고 학습하며 성장하는 카카오와 구름이 함께하는 대학생 대상 해커톤", fields: [Field.PM, Field.DESIGN, Field.WEB, Field.SPRING, Field.REACT_NATIVE] },
     // 2025-02-18
     COTATO_1: { name: "코테이토 (1학기)", link: "https://www.cotato.kr/", dots: "🌕🌗", icon: "🥔", themeColor: "slate-500", recruitStart: "2월 19일 2026", recruitEnd: "2월 24일 2026", activity: ["3월", "4월", "5월", "6월"], eligibility: [Eligibility.UNIVERSITY], description: "IT 서비스 기획부터 개발, 출시에 이르기까지 전 과정을 경험할 수 있는 대학생 IT 연합 동아리", fields: [Field.PM, Field.DESIGN, Field.WEB, Field.NODE, Field.SPRING] },
     // 2025-03-08


### PR DESCRIPTION
## Summary
- 구름톤 유니브 모집 일정을 2월 26일 ~ 3월 23일 2026으로 변경

## Test plan
- [ ] 구름톤 유니브 카드에 변경된 일정이 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)