### PR TITLE
[fix] 이스터에그를 IT 연합동아리 페이지에서만 동작하도록 제한

### DIFF
--- a/script.js
+++ b/script.js
@@ -833,8 +833,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 
-// 🦕 Easter Egg
+// 🦕 Easter Egg (IT 연합동아리 페이지에서만 동작)
 (function() {
+    if (getPageName() !== 'it') return;
+
     const logo = document.querySelector('header img[alt="Logo"]');
     if (!logo) return;
 


### PR DESCRIPTION
## Summary
- 공룡 로고 클릭 이스터에그(인프런 쿠폰)가 IT 연합동아리 모음 페이지에서만 동작하도록 제한
- `getPageName() !== 'it'`일 경우 이스터에그 초기화를 건너뛰도록 조건 추가

closes #73

## Test plan
- [ ] IT 연합동아리 페이지(index.html)에서 공룡 로고 클릭 시 쿠폰 모달 표시 확인
- [ ] 마케팅, 해커톤, 부트캠프 페이지에서 공룡 로고 클릭 시 아무 반응 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)