### PR TITLE
[fix] 추천 페이지 헤더 타이틀 변경 및 이스터에그 비활성화

### DIFF
--- a/recommend.html
+++ b/recommend.html
@@ -2,7 +2,7 @@
 <html lang="ko"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>나에게 맞는 동아리 찾기 | IT 연합 동아리 모음</title>
+<title>나에게 맞는 동아리 찾기 | IT 연합동아리 추천</title>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Sans+KR:wght@400;500;700&amp;display=swap" rel="stylesheet"/>
@@ -69,7 +69,7 @@
 <img src="logo.png" alt="Logo" class="h-8 sm:h-10 md:h-12 w-auto" />
 </a>
 <a href="/" class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight text-slate-900 dark:text-slate-100 hover:opacity-80 transition-opacity">
-    IT 연합 동아리 모음
+    IT 연합동아리 추천
 </a>
 <a class="ml-auto shrink-0 inline-flex items-center gap-1 sm:gap-1.5 px-3 py-1.5 sm:px-4 sm:py-2 rounded-full border border-purple-400/30 bg-purple-500/10 text-purple-500 dark:text-purple-400 font-medium text-xs sm:text-sm hover:bg-purple-500/20 hover:border-purple-400/50 transition-all" href="https://docs.google.com/forms/d/1A7zV5F8fGpHuC7NPs3juTnIlfEuo8hlMfpoo_aKC7rs/edit" target="_blank">
     <span class="material-symbols-outlined text-sm sm:text-base">feedback</span>

--- a/script.js
+++ b/script.js
@@ -902,9 +902,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 
-// 🦕 Easter Egg (IT 연합동아리 페이지에서만 동작)
+// 🦕 Easter Egg (IT 연합동아리 메인 페이지에서만 동작, 추천 페이지 제외)
 (function() {
     if (getPageName() !== 'it') return;
+    if (window.isRecommendPage) return;
 
     const logo = document.querySelector('header img[alt="Logo"]');
     if (!logo) return;


### PR DESCRIPTION
## Summary
- 추천 페이지(recommend.html) 헤더 타이틀을 "IT 연합동아리 추천"으로 변경
- 추천 페이지에서 로고(공룡) 클릭 시 쿠폰 이스터에그 모달이 뜨지 않도록 수정

Closes #75

## Test plan
- [ ] 추천 페이지 접속 시 헤더가 "IT 연합동아리 추천"으로 표시되는지 확인
- [ ] 추천 페이지에서 로고 클릭 시 쿠폰 모달이 뜨지 않는지 확인
- [ ] 메인 페이지에서는 기존대로 이스터에그가 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)