### PR TITLE
[feat] 제휴 광고 옵션 미리보기 페이지 추가

### DIFF
--- a/partnership.html
+++ b/partnership.html
@@ -116,7 +116,7 @@
 <!-- 옵션 1: 상단 배너 광고 -->
 <!-- ======================================================================== -->
 <section class="mx-4 sm:mx-6 md:mx-12 lg:mx-auto lg:max-w-7xl">
-    <div class="flex items-center gap-3 mt-12 mb-2">
+    <div class="flex items-center gap-3 mt-12 mb-2 pl-2">
         <span class="flex items-center justify-center w-10 h-10 rounded-xl bg-blue-500 text-white font-bold text-lg shrink-0">1</span>
         <div>
             <h2 class="text-xl sm:text-2xl font-bold">상단 배너 광고</h2>
@@ -224,8 +224,7 @@
     <div class="px-4 mb-3">
         <div class="rounded-2xl overflow-hidden bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 p-4 relative">
             <div class="absolute top-2 right-2 px-2 py-0.5 rounded-full bg-white/20 text-white text-[10px] font-medium backdrop-blur-sm">AD</div>
-            <div class="flex items-center gap-2 mb-2"><span class="text-2xl">🏆</span><div><h3 class="text-white font-bold text-sm">테카 - 2026 상반기 모집 중!</h3><p class="text-blue-100 text-xs">데이터 사이언스 & AI 해커톤 동아리</p></div></div>
-            <span class="inline-block px-4 py-1.5 rounded-full bg-white text-indigo-600 font-bold text-xs mt-1">지원하기 →</span>
+            <div class="flex items-center gap-2"><span class="text-2xl">🏆</span><div><h3 class="text-white font-bold text-sm">테카 - 2026 상반기 모집 중!</h3><p class="text-blue-100 text-xs">데이터 사이언스 & AI 해커톤 동아리</p></div><span class="ml-auto shrink-0 px-3 py-1.5 rounded-full bg-white text-indigo-600 font-bold text-xs">지원하기 →</span></div>
         </div>
     </div>
     <!-- 다가오는 일정 -->
@@ -281,7 +280,7 @@
 <!-- 옵션 2: 카드 글로우 & 배경 효과 -->
 <!-- ======================================================================== -->
 <section class="mx-4 sm:mx-6 md:mx-12 lg:mx-auto lg:max-w-7xl">
-    <div class="flex items-center gap-3 mt-12 mb-2">
+    <div class="flex items-center gap-3 mt-12 mb-2 pl-2">
         <span class="flex items-center justify-center w-10 h-10 rounded-xl bg-purple-500 text-white font-bold text-lg shrink-0">2</span>
         <div>
             <h2 class="text-xl sm:text-2xl font-bold">카드 글로우 & 배경 효과</h2>
@@ -417,7 +416,7 @@
 <!-- 옵션 3: 다가오는 일정 최우선 배치 -->
 <!-- ======================================================================== -->
 <section class="mx-4 sm:mx-6 md:mx-12 lg:mx-auto lg:max-w-7xl">
-    <div class="flex items-center gap-3 mt-12 mb-2">
+    <div class="flex items-center gap-3 mt-12 mb-2 pl-2">
         <span class="flex items-center justify-center w-10 h-10 rounded-xl bg-pink-500 text-white font-bold text-lg shrink-0">3</span>
         <div>
             <h2 class="text-xl sm:text-2xl font-bold">다가오는 일정 최우선 배치</h2>
@@ -534,7 +533,7 @@
 <!-- 옵션 4: 티어 조정 -->
 <!-- ======================================================================== -->
 <section class="mx-4 sm:mx-6 md:mx-12 lg:mx-auto lg:max-w-7xl">
-    <div class="flex items-center gap-3 mt-12 mb-2">
+    <div class="flex items-center gap-3 mt-12 mb-2 pl-2">
         <span class="flex items-center justify-center w-10 h-10 rounded-xl bg-amber-500 text-white font-bold text-lg shrink-0">4</span>
         <div>
             <h2 class="text-xl sm:text-2xl font-bold">동아리 목록 최상단 배치</h2>


### PR DESCRIPTION
## Summary
- 제휴 시 적용되는 4가지 광고 옵션을 실제 화면 기준으로 미리볼 수 있는 `partnership.html` 페이지 추가
  1. 상단 배너 광고
  2. 카드 글로우 & 배경 효과
  3. 다가오는 일정 최우선 배치
  4. 동아리 목록 최상단 배치
- 각 옵션별 PC/모바일 토글 뷰 지원 (모바일은 390px 폰 화면 시뮬레이션)
- 예시 동아리 "테카"를 사용하여 각 광고 효과를 시각적으로 확인 가능

## Test plan
- [ ] partnership.html 접속 후 4개 섹션이 정상적으로 렌더링되는지 확인
- [ ] 각 섹션의 PC/Mobile 토글 버튼 클릭 시 뷰 전환이 정상 동작하는지 확인
- [ ] 모바일 뷰에서 카드 레이아웃, 배너, 글로우 효과 등이 올바르게 표시되는지 확인
- [ ] 다크 모드에서 정상적으로 표시되는지 확인

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)