### PR TITLE
[feat] Microsoft Clarity 히트맵 트래킹 코드 추가

### DIFF
--- a/bootcamp.html
+++ b/bootcamp.html
@@ -52,6 +52,13 @@
     </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7331924992804617" crossorigin="anonymous"></script>
 <link href="style.css" rel="stylesheet"/>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="min-h-screen flex flex-col">

--- a/hackathon.html
+++ b/hackathon.html
@@ -52,6 +52,13 @@
     </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7331924992804617" crossorigin="anonymous"></script>
 <link href="style.css" rel="stylesheet"/>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="min-h-screen flex flex-col">

--- a/index.html
+++ b/index.html
@@ -52,6 +52,13 @@
     </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7331924992804617" crossorigin="anonymous"></script>
 <link href="style.css" rel="stylesheet"/>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="min-h-screen flex flex-col">

--- a/marketing.html
+++ b/marketing.html
@@ -52,6 +52,13 @@
     </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7331924992804617" crossorigin="anonymous"></script>
 <link href="style.css" rel="stylesheet"/>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="min-h-screen flex flex-col">

--- a/partnership.html
+++ b/partnership.html
@@ -94,6 +94,13 @@
         overflow-y: auto;
     }
 </style>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="min-h-screen flex flex-col">

--- a/recommend.html
+++ b/recommend.html
@@ -60,6 +60,13 @@
         }
     }
 </style>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="flex flex-col">

--- a/tournament-top10.html
+++ b/tournament-top10.html
@@ -38,6 +38,13 @@
     };
 </script>
 <link href="style.css" rel="stylesheet"/>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="min-h-screen flex flex-col">

--- a/tournament.html
+++ b/tournament.html
@@ -124,6 +124,13 @@
         transform: scale(0.98);
     }
 </style>
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xf80ewqiem");
+</script>
 </head>
 <body class="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 transition-colors duration-200">
 <div class="min-h-screen flex flex-col">


### PR DESCRIPTION
## Summary
- 8개 HTML 파일의 `<head>` 섹션에 Microsoft Clarity 트래킹 스크립트 삽입
- 히트맵, 세션 리코딩, Dead click/Rage click 감지 등 사용자 행동 분석 기능 추가
- Clarity 프로젝트 ID: `xf80ewqiem`

## 대상 파일
- index.html, marketing.html, bootcamp.html, hackathon.html
- tournament.html, tournament-top10.html, recommend.html, partnership.html

## 검증 방법
- [ ] 배포 후 DevTools → Network에서 `clarity.ms/collect` POST 요청 확인
- [ ] [Clarity 대시보드](https://clarity.microsoft.com)에서 실시간 데이터 수집 확인
- [ ] Heatmaps 탭에서 히트맵 생성 확인

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)