### PR TITLE
[feat] 다가오는 일정 스켈레톤 UI 추가

### DIFF
--- a/bootcamp.html
+++ b/bootcamp.html
@@ -104,6 +104,12 @@
             </h2>
 <div class="flex gap-4 overflow-x-auto pb-4 notion-scroll" id="upcoming-deadlines">
 </div>
+<script>
+(function(){
+var d='<div class="flex-shrink-0 w-72 p-5 rounded-2xl border border-slate-200 dark:border-border-dark bg-emerald-50 dark:bg-slate-900/40 animate-pulse"><div class="flex justify-between items-start mb-4"><div class="w-8 h-8 bg-slate-200 dark:bg-slate-700 rounded"></div></div><div class="w-32 h-5 bg-slate-200 dark:bg-slate-700 rounded mb-1"></div><div class="w-40 h-4 bg-slate-200 dark:bg-slate-700 rounded"></div></div>';
+document.getElementById('upcoming-deadlines').innerHTML=d.repeat(5);
+})();
+</script>
 </section>
 <div class="px-4 sm:px-6 md:px-12 max-w-7xl mx-auto w-full mb-4 md:mb-6">
 <div class="flex flex-col md:flex-row gap-3 md:gap-4 items-stretch md:items-center">

--- a/hackathon.html
+++ b/hackathon.html
@@ -104,6 +104,12 @@
             </h2>
 <div class="flex gap-4 overflow-x-auto pb-4 notion-scroll" id="upcoming-deadlines">
 </div>
+<script>
+(function(){
+var d='<div class="flex-shrink-0 w-72 p-5 rounded-2xl border border-slate-200 dark:border-border-dark bg-violet-50 dark:bg-slate-900/40 animate-pulse"><div class="flex justify-between items-start mb-4"><div class="w-8 h-8 bg-slate-200 dark:bg-slate-700 rounded"></div></div><div class="w-32 h-5 bg-slate-200 dark:bg-slate-700 rounded mb-1"></div><div class="w-40 h-4 bg-slate-200 dark:bg-slate-700 rounded"></div></div>';
+document.getElementById('upcoming-deadlines').innerHTML=d.repeat(5);
+})();
+</script>
 </section>
 <div class="px-4 sm:px-6 md:px-12 max-w-7xl mx-auto w-full mb-4 md:mb-6">
 <div class="flex flex-col md:flex-row gap-3 md:gap-4 items-stretch md:items-center">

--- a/index.html
+++ b/index.html
@@ -111,6 +111,12 @@
             </h2>
 <div class="flex gap-4 overflow-x-auto pb-4 notion-scroll" id="upcoming-deadlines">
 </div>
+<script>
+(function(){
+var d='<div class="flex-shrink-0 w-72 p-5 rounded-2xl border border-slate-200 dark:border-border-dark bg-blue-50 dark:bg-slate-900/40 animate-pulse"><div class="flex justify-between items-start mb-4"><div class="w-8 h-8 bg-slate-200 dark:bg-slate-700 rounded"></div></div><div class="w-32 h-5 bg-slate-200 dark:bg-slate-700 rounded mb-1"></div><div class="w-40 h-4 bg-slate-200 dark:bg-slate-700 rounded"></div></div>';
+document.getElementById('upcoming-deadlines').innerHTML=d.repeat(5);
+})();
+</script>
 </section>
 <div class="px-4 sm:px-6 md:px-12 max-w-7xl mx-auto w-full mb-4 md:mb-6">
 <div class="flex flex-col md:flex-row gap-3 md:gap-4 items-stretch md:items-center">

--- a/marketing.html
+++ b/marketing.html
@@ -104,6 +104,12 @@
             </h2>
 <div class="flex gap-4 overflow-x-auto pb-4 notion-scroll" id="upcoming-deadlines">
 </div>
+<script>
+(function(){
+var d='<div class="flex-shrink-0 w-72 p-5 rounded-2xl border border-slate-200 dark:border-border-dark bg-pink-50 dark:bg-slate-900/40 animate-pulse"><div class="flex justify-between items-start mb-4"><div class="w-8 h-8 bg-slate-200 dark:bg-slate-700 rounded"></div></div><div class="w-32 h-5 bg-slate-200 dark:bg-slate-700 rounded mb-1"></div><div class="w-40 h-4 bg-slate-200 dark:bg-slate-700 rounded"></div></div>';
+document.getElementById('upcoming-deadlines').innerHTML=d.repeat(5);
+})();
+</script>
 </section>
 <div class="px-4 sm:px-6 md:px-12 max-w-7xl mx-auto w-full mb-4 md:mb-6">
 <div class="flex flex-col md:flex-row gap-3 md:gap-4 items-stretch md:items-center">


### PR DESCRIPTION
## Summary
- 다가오는 일정 섹션(`#upcoming-deadlines`)에 스켈레톤 placeholder 5개 추가
- 각 페이지 테마 색상에 맞춤 (blue/pink/emerald/violet)
- `renderDeadlines()`가 `innerHTML`로 교체하므로 JS 수정 불필요

## 검증 방법
- [ ] 각 페이지 새로고침 시 다가오는 일정 영역에 스켈레톤 카드 표시 확인
- [ ] 다크모드 정상 표시 확인

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)