### PR TITLE
[fix] 추천 알고리즘 시기 필터를 활동 기간 기준으로 변경

### DIFF
--- a/recommend.html
+++ b/recommend.html
@@ -386,12 +386,6 @@
         // 0. Marketing 동아리 제외 (프로그래피 예외)
         if (club.fields.some(f => f.name === "Marketing") && !club.name.includes("프로그래피")) return -1;
 
-        // 0-1. Recruit period hard filter (활동 시기를 선택한 경우에만 적용)
-        if (answers.timing !== "any") {
-            const endDate = parseKoreanDate(club.recruitEnd);
-            if (endDate && endDate < new Date()) return -1;
-        }
-
         // 1. Eligibility hard filter
         const userElig = answers.eligibility;
         let eligible = false;

--- a/script.js
+++ b/script.js
@@ -54,7 +54,7 @@ const FilterCategory = {
     [Category.PM]: ["PM"],
     [Category.DESIGN]: ["Design", "UX"],
     [Category.AI]: ["AI", "머신러닝", "딥러닝", "LLM", "데이터 분석", "데이터 시각화", "데이터 엔지니어링"],
-    [Category.WEB]: ["WEB"],
+    [Category.WEB]: ["WEB", "Frontend"],
     [Category.MOBILE]: ["Android", "iOS", "ReactNative", "Flutter", "앱"],
     [Category.BACKEND]: ["Backend", "SpringBoot", "Node.js", "Django"],
     [Category.ANY]: ["무관"],

--- a/script.js
+++ b/script.js
@@ -54,7 +54,7 @@ const FilterCategory = {
     [Category.PM]: ["PM"],
     [Category.DESIGN]: ["Design", "UX"],
     [Category.AI]: ["AI", "머신러닝", "딥러닝", "LLM", "데이터 분석", "데이터 시각화", "데이터 엔지니어링"],
-    [Category.WEB]: ["WEB", "Frontend"],
+    [Category.WEB]: ["WEB"],
     [Category.MOBILE]: ["Android", "iOS", "ReactNative", "Flutter", "앱"],
     [Category.BACKEND]: ["Backend", "SpringBoot", "Node.js", "Django"],
     [Category.ANY]: ["무관"],


### PR DESCRIPTION
## Summary
- 추천 알고리즘에서 모집 마감일(`recruitEnd`) 기반 hard filter 제거
- 활동 기간(`activity`) 기반 스코어링만으로 시기 매칭 수행
- `FilterCategory`에서 stale "Frontend" 참조 제거

## 변경 이유
시기 선택 시 모집 마감일 기준으로 필터링하면, 오늘 기준 모집이 끝난 동아리가 모두 제외되어 결과가 0건이 됨. 활동 기간을 기준으로 매칭해야 사용자에게 유의미한 추천 결과 제공 가능.

## Test plan
- [ ] 현직자 + 웹 + 여름방학 조건으로 추천 결과 확인
- [ ] 대학생 + 웹 + 여름방학 조건으로 추천 결과 확인
- [ ] 시기 "상관없어요" 선택 시 기존과 동일하게 동작하는지 확인

closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)