### PR TITLE
전체 페이지 SEO 메타 태그 추가

### DIFF
--- a/bootcamp.html
+++ b/bootcamp.html
@@ -3,15 +3,15 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>2026 부트캠프 추천 순위 비교 | TECA</title>
-<meta name="description" content="SSAFY, 우아한테크코스, 카카오 부트캠프 등 2026년 국내 부트캠프를 한눈에 비교하세요. 국비지원·무료·유료 비용, 모집 기간, 교육 분야별 필터링까지. 매일 업데이트."/>
+<meta name="description" content="국내 부트캠프를 한눈에 비교하세요. 국비지원·무료·유료 비용, 모집 기간, 교육 분야별 필터링까지. 매일 업데이트."/>
 <link rel="canonical" href="https://teca-official.co.kr/bootcamp"/>
 <meta property="og:title" content="2026 부트캠프 추천 순위 비교 | TECA"/>
-<meta property="og:description" content="SSAFY, 우아한테크코스, 카카오 부트캠프 등 국비지원·무료 부트캠프를 한눈에 비교"/>
+<meta property="og:description" content="국내 부트캠프를 한눈에 비교하세요. 국비지원·무료·유료 비용, 모집 기간, 교육 분야별 필터링까지."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://teca-official.co.kr/bootcamp"/>
 <meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:title" content="2026 부트캠프 추천 순위 비교 | TECA"/>
-<meta name="twitter:description" content="SSAFY, 우아한테크코스, 카카오 부트캠프 등 국비지원·무료 부트캠프를 한눈에 비교"/>
+<meta name="twitter:description" content="국내 부트캠프를 한눈에 비교하세요. 국비지원·무료·유료 비용, 모집 기간, 교육 분야별 필터링까지."/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Sans+KR:wght@400;500;700&amp;display=swap" rel="stylesheet"/>

--- a/hackathon.html
+++ b/hackathon.html
@@ -2,7 +2,16 @@
 <html lang="ko"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>해커톤/대회 모음</title>
+<title>2026 해커톤 대회 일정 모음 | TECA</title>
+<meta name="description" content="해커톤, AI 대회, 공모전 등 2026년 국내 IT 대회 일정을 한눈에 확인하세요. 마감 임박 순 정렬, 상금·채용우대 필터링까지. 매일 업데이트."/>
+<link rel="canonical" href="https://teca-official.co.kr/hackathon"/>
+<meta property="og:title" content="2026 해커톤 대회 일정 모음 | TECA"/>
+<meta property="og:description" content="2026년 국내 해커톤, AI 대회, 공모전 일정을 한눈에 확인"/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://teca-official.co.kr/hackathon"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="2026 해커톤 대회 일정 모음 | TECA"/>
+<meta name="twitter:description" content="2026년 국내 해커톤, AI 대회, 공모전 일정을 한눈에 확인"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Sans+KR:wght@400;500;700&amp;display=swap" rel="stylesheet"/>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,16 @@
 <html lang="ko"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>IT 연합 동아리 모음</title>
+<title>IT 연합동아리 모음 추천 순위 | TECA</title>
+<meta name="description" content="국내 IT 연합동아리를 한눈에 비교하세요. 모집 기간, 분야, 티어별 필터링까지."/>
+<link rel="canonical" href="https://teca-official.co.kr/"/>
+<meta property="og:title" content="IT 연합동아리 모음 추천 순위 | TECA"/>
+<meta property="og:description" content="국내 IT 연합동아리를 한눈에 비교하세요. 모집 기간, 분야, 티어별 필터링까지."/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://teca-official.co.kr/"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="IT 연합동아리 모음 추천 순위 | TECA"/>
+<meta name="twitter:description" content="국내 IT 연합동아리를 한눈에 비교하세요. 모집 기간, 분야, 티어별 필터링까지."/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Sans+KR:wght@400;500;700&amp;display=swap" rel="stylesheet"/>

--- a/marketing.html
+++ b/marketing.html
@@ -2,7 +2,16 @@
 <html lang="ko"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>마케팅/경영 연합 동아리 모음</title>
+<title>마케팅 경영 연합동아리 모음 | TECA</title>
+<meta name="description" content="마케팅, PM, 경영 분야 대학생 연합동아리를 한눈에 비교하세요. 모집 기간, 분야별 필터링까지."/>
+<link rel="canonical" href="https://teca-official.co.kr/marketing"/>
+<meta property="og:title" content="마케팅 경영 연합동아리 모음 | TECA"/>
+<meta property="og:description" content="마케팅, PM, 경영 분야 대학생 연합동아리를 한눈에 비교하세요."/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://teca-official.co.kr/marketing"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="마케팅 경영 연합동아리 모음 | TECA"/>
+<meta name="twitter:description" content="마케팅, PM, 경영 분야 대학생 연합동아리를 한눈에 비교하세요."/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Sans+KR:wght@400;500;700&amp;display=swap" rel="stylesheet"/>

--- a/recommend.html
+++ b/recommend.html
@@ -3,6 +3,15 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>나에게 맞는 동아리 찾기 | IT 연합동아리 추천</title>
+<meta name="description" content="3가지 질문으로 나에게 맞는 IT 동아리를 추천받으세요. AI 기반 맞춤 추천."/>
+<link rel="canonical" href="https://teca-official.co.kr/recommend"/>
+<meta property="og:title" content="나에게 맞는 동아리 찾기 | IT 연합동아리 추천"/>
+<meta property="og:description" content="3가지 질문으로 나에게 맞는 IT 동아리를 추천받으세요."/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://teca-official.co.kr/recommend"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="나에게 맞는 동아리 찾기 | IT 연합동아리 추천"/>
+<meta name="twitter:description" content="3가지 질문으로 나에게 맞는 IT 동아리를 추천받으세요."/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Sans+KR:wght@400;500;700&amp;display=swap" rel="stylesheet"/>


### PR DESCRIPTION
## Summary
- hackathon.html: title 개선, description/canonical/OG/Twitter 추가
- index.html: title 개선, description/canonical/OG/Twitter 추가
- marketing.html: title 개선, description/canonical/OG/Twitter 추가
- recommend.html: description/canonical/OG/Twitter 추가
- bootcamp.html: description에서 특정 부트캠프 이름 제거하여 스타일 통일

closes #142

## Test plan
- [ ] 각 페이지 브라우저 탭에서 title 확인
- [ ] 페이지 소스 보기로 meta 태그 확인
- [ ] SNS 공유 시 OG 미리보기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)